### PR TITLE
Add first and last to aggregate expressions

### DIFF
--- a/Chronological.Tests/MeasureExpressionTests.cs
+++ b/Chronological.Tests/MeasureExpressionTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -8,11 +9,51 @@ namespace Chronological.Tests
     {
         [Fact]
         public void Test1()
-        {                        
+        {
             var measure = new Measure<TestType1>(Property<double>.Create<TestType1>(x => x.Value), Measure.MaximumMeasureExpression);
-            
+
             Assert.Equal(measure.MeasureType, Measure.MaximumMeasureExpression);
-            Assert.True(JToken.DeepEquals(measure.Property.ToInputJProperty(), TestType1JProperties.Value));                       
+            Assert.True(JToken.DeepEquals(measure.Property.ToInputJProperty(), TestType1JProperties.Value));
+        }
+
+        [Fact]
+        public void WhenUsingFirstInMeasureWithoutOrderByShouldReturnCorrectJson()
+        {
+            var measure = new Measure<TestType1>(Property<double>.Create<TestType1>(x => x.Value),
+                Measure.FirstMeasureExpression);
+
+            Assert.Equal(measure.MeasureType, Measure.FirstMeasureExpression);
+            Assert.True(JToken.DeepEquals(measure.ToJProperty(), TestType1JProperties.FirstMeasureWithoutOrderBy));
+        }
+
+        [Fact]
+        public void WhenUsingLastInMeasureWithoutOrderByShouldReturnCorrectJson()
+        {
+            var measure = new Measure<TestType1>(Property<double>.Create<TestType1>(x => x.Value),
+                Measure.LastMeasureExpression);
+
+            Assert.Equal(measure.MeasureType, Measure.LastMeasureExpression);
+            Assert.True(JToken.DeepEquals(measure.ToJProperty(), TestType1JProperties.LastMeasureWithoutOrderBy));
+        }
+
+        [Fact]
+        public void WhenUsingFirstInMeasureWithOrderByShouldReturnCorrectJson()
+        {
+            var measure = new Measure<TestType1>(Property<double>.Create<TestType1>(x => x.Value),
+                Measure.FirstMeasureExpression, Property<DateTime>.Create<TestType1>(x => x.Date));
+
+            Assert.Equal(measure.MeasureType, Measure.FirstMeasureExpression);
+            Assert.True(JToken.DeepEquals(measure.ToJProperty(), TestType1JProperties.FirstMeasureWithOrderBy));
+        }
+
+        [Fact]
+        public void WhenUsingLastInMeasureWithOrderByShouldReturnCorrectJson()
+        {
+            var measure = new Measure<TestType1>(Property<double>.Create<TestType1>(x => x.Value),
+                Measure.LastMeasureExpression, Property<DateTime>.Create<TestType1>(x => x.Date));
+
+            Assert.Equal(measure.MeasureType, Measure.LastMeasureExpression);
+            Assert.True(JToken.DeepEquals(measure.ToJProperty(), TestType1JProperties.LastMeasureWithOrderBy));
         }
 
         [Fact]

--- a/Chronological.Tests/TestType1.cs
+++ b/Chronological.Tests/TestType1.cs
@@ -16,20 +16,32 @@ namespace Chronological.Tests
 
         [ChronologicalEventField("data.type")]
         public string DataType { get; set; }
+
         [ChronologicalEventField("data.value")]
         public double Value { get; set; }
+
         [ChronologicalEventField("data.isSimulated")]
         public bool? IsSimulated { get; set; }
-
     }
 
-    public class TestType1JProperties
+    public static class TestType1JProperties
     {
         public static JProperty Value => new JProperty("input",
             new JObject(new JProperty("property", "data.value"), new JProperty("type", "Double")));
 
         public static JProperty Date => new JProperty("input",
             new JObject(new JProperty("builtInProperty", "$ts")));
+
+        public static JProperty LastMeasureWithoutOrderBy => new JProperty("last",
+            new JObject(Value));
+
+        public static JProperty FirstMeasureWithoutOrderBy => new JProperty("first",
+            new JObject(Value));
+
+        public static JProperty LastMeasureWithOrderBy => new JProperty("last",
+            new JObject(Value, new JProperty("orderBy", new JObject(new JProperty("builtInProperty", "$ts")))));
+
+        public static JProperty FirstMeasureWithOrderBy => new JProperty("first",
+            new JObject(Value, new JProperty("orderBy", new JObject(new JProperty("builtInProperty", "$ts")))));
     }
-    
 }

--- a/Chronological.Tests/UniqueValuesAggregateTests.cs
+++ b/Chronological.Tests/UniqueValuesAggregateTests.cs
@@ -12,6 +12,11 @@ namespace Chronological.Tests
             return new JProperty("measures", measureJArray);
         }
 
+        public static JProperty ExpectedLastResult()
+        {
+            return new JProperty("measures", new JArray(new JObject(TestType1JProperties.LastMeasureWithOrderBy)));
+        }
+
         [Fact]
         public void Test1()
         {
@@ -20,6 +25,17 @@ namespace Chronological.Tests
 
             var test = aggregate.ToChildJProperty();
             var expected = ExpectedResult();
+            Assert.True(JToken.DeepEquals(test, expected));
+        }
+
+        [Fact]
+        public void UsingLastInAggregateShouldGiveCorrectJson()
+        {
+            var builder = new AggregateBuilder<TestType1>();
+            var aggregate = builder.UniqueValues(x => x.DataType, 10, new { Last = builder.Last(x => x.Value, y => y.Date) });
+
+            var test = aggregate.ToChildJProperty();
+            var expected = ExpectedLastResult();
             Assert.True(JToken.DeepEquals(test, expected));
         }
 

--- a/Chronological.Tests/UniqueValuesAggregateTests.cs
+++ b/Chronological.Tests/UniqueValuesAggregateTests.cs
@@ -17,6 +17,11 @@ namespace Chronological.Tests
             return new JProperty("measures", new JArray(new JObject(TestType1JProperties.LastMeasureWithOrderBy)));
         }
 
+        public static JProperty ExpectedFirstResult()
+        {
+            return new JProperty("measures", new JArray(new JObject(TestType1JProperties.FirstMeasureWithOrderBy)));
+        }
+
         [Fact]
         public void Test1()
         {
@@ -36,6 +41,17 @@ namespace Chronological.Tests
 
             var test = aggregate.ToChildJProperty();
             var expected = ExpectedLastResult();
+            Assert.True(JToken.DeepEquals(test, expected));
+        }
+
+        [Fact]
+        public void UsingFirstInAggregateShouldGiveCorrectJson()
+        {
+            var builder = new AggregateBuilder<TestType1>();
+            var aggregate = builder.UniqueValues(x => x.DataType, 10, new { Last = builder.First(x => x.Value, y => y.Date) });
+
+            var test = aggregate.ToChildJProperty();
+            var expected = ExpectedFirstResult();
             Assert.True(JToken.DeepEquals(test, expected));
         }
 
@@ -75,6 +91,44 @@ namespace Chronological.Tests
 
             var test = aggregate.ToChildJProperty();
             var expected = ExpectedNestedResult();
+            Assert.True(JToken.DeepEquals(test, expected));
+        }
+        public JProperty ExpectedLastNestedResult()
+        {
+            var test = JToken.Parse(@"{'aggregate': {
+                                      'dimension': {
+                                        'uniqueValues': {
+                                          'input': {
+                                            'property': 'data.value',
+                                            'type': 'Double'
+                                          },
+                                          'take': 10
+                                        }
+                                      },
+                                      'measures': [
+                                        {
+                                          'last': {
+                                            'input': {
+                                              'property': 'data.value',
+                                              'type': 'Double'
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    }}");
+            return (JProperty)test.First;
+        }
+
+        [Fact]
+        public void NestedAggregateWithLast()
+        {
+            var builder = new AggregateBuilder<TestType1>();
+            var aggregate = builder.UniqueValues(x => x.Value, 10,
+                builder.UniqueValues(x => x.Value, 10,
+                    new { Last = builder.Last(x => x.Value) }));
+
+            var test = aggregate.ToChildJProperty();
+            var expected = ExpectedLastNestedResult();
             Assert.True(JToken.DeepEquals(test, expected));
         }
     }

--- a/Chronological/AggregateBuilder[T].cs
+++ b/Chronological/AggregateBuilder[T].cs
@@ -50,12 +50,12 @@ namespace Chronological
             return Measure<int>.Create(Measure.CountMeasureExpression);
         }
 
-        public Measure<TY> Last<TY>(Expression<Func<T, TY>> property, Expression<Func<T, TY>> orderBy = null)
+        public Measure<TY> Last<TY, TZ>(Expression<Func<T, TY>> property, Expression<Func<T, TZ>> orderBy = null)
         {
             return Measure<TY>.Create(property, Measure.LastMeasureExpression, orderBy);
         }
 
-        public Measure<TY> First<TY>(Expression<Func<T, TY>> property, Expression<Func<T, TY>> orderBy = null)
+        public Measure<TY> First<TY, TZ>(Expression<Func<T, TY>> property, Expression<Func<T, TZ>> orderBy = null)
         {
             return Measure<TY>.Create(property, Measure.FirstMeasureExpression, orderBy);
         }

--- a/Chronological/AggregateBuilder[T].cs
+++ b/Chronological/AggregateBuilder[T].cs
@@ -50,5 +50,14 @@ namespace Chronological
             return Measure<int>.Create(Measure.CountMeasureExpression);
         }
 
+        public Measure<TY> Last<TY>(Expression<Func<T, TY>> property)
+        {
+            return Measure<TY>.Create(property, Measure.LastMeasureExpression);
+        }
+
+        public Measure<TY> First<TY>(Expression<Func<T, TY>> property)
+        {
+            return Measure<TY>.Create(property, Measure.FirstMeasureExpression);
+        }
     }
 }

--- a/Chronological/AggregateBuilder[T].cs
+++ b/Chronological/AggregateBuilder[T].cs
@@ -50,12 +50,22 @@ namespace Chronological
             return Measure<int>.Create(Measure.CountMeasureExpression);
         }
 
-        public Measure<TY> Last<TY, TZ>(Expression<Func<T, TY>> property, Expression<Func<T, TZ>> orderBy = null)
+        public Measure<TY> Last<TY>(Expression<Func<T, TY>> property)
+        {
+            return Last<TY, object>(property, null);
+        }
+
+        public Measure<TY> First<TY>(Expression<Func<T, TY>> property)
+        {
+            return First<TY, object>(property, null);
+        }
+
+        public Measure<TY> Last<TY, TZ>(Expression<Func<T, TY>> property, Expression<Func<T, TZ>> orderBy)
         {
             return Measure<TY>.Create(property, Measure.LastMeasureExpression, orderBy);
         }
 
-        public Measure<TY> First<TY, TZ>(Expression<Func<T, TY>> property, Expression<Func<T, TZ>> orderBy = null)
+        public Measure<TY> First<TY, TZ>(Expression<Func<T, TY>> property, Expression<Func<T, TZ>> orderBy)
         {
             return Measure<TY>.Create(property, Measure.FirstMeasureExpression, orderBy);
         }

--- a/Chronological/AggregateBuilder[T].cs
+++ b/Chronological/AggregateBuilder[T].cs
@@ -50,14 +50,14 @@ namespace Chronological
             return Measure<int>.Create(Measure.CountMeasureExpression);
         }
 
-        public Measure<TY> Last<TY>(Expression<Func<T, TY>> property)
+        public Measure<TY> Last<TY>(Expression<Func<T, TY>> property, Expression<Func<T, TY>> orderBy = null)
         {
-            return Measure<TY>.Create(property, Measure.LastMeasureExpression);
+            return Measure<TY>.Create(property, Measure.LastMeasureExpression, orderBy);
         }
 
-        public Measure<TY> First<TY>(Expression<Func<T, TY>> property)
+        public Measure<TY> First<TY>(Expression<Func<T, TY>> property, Expression<Func<T, TY>> orderBy = null)
         {
-            return Measure<TY>.Create(property, Measure.FirstMeasureExpression);
+            return Measure<TY>.Create(property, Measure.FirstMeasureExpression, orderBy);
         }
     }
 }

--- a/Chronological/Measure.cs
+++ b/Chronological/Measure.cs
@@ -42,18 +42,23 @@ namespace Chronological
             return new Measure<T>(Property, MeasureType, value.ToObject<T>());
         }
 
-        internal static Measure<T> Create<TY>(Expression<Func<TY, T>> propertyExpression, string measureType, Expression<Func<TY, T>> orderByExpression = null)
+        internal static Measure<T> Create<TY>(Expression<Func<TY, T>> propertyExpression, string measureType)
+        {
+            return Create<TY, object>(propertyExpression, measureType, null);
+        }
+
+        internal static Measure<T> Create<TY, TZ>(Expression<Func<TY, T>> propertyExpression, string measureType, Expression<Func<TY, TZ>> orderByExpression)
         {
             var property = Property<T>.Create(propertyExpression);
 
             if (orderByExpression == null)
                 return new Measure<T>(property, measureType);
 
-            if (measureType != Measure.LastMeasureExpression || measureType != Measure.FirstMeasureExpression)
+            if (measureType != Measure.LastMeasureExpression && measureType != Measure.FirstMeasureExpression)
             {
                 throw new NotSupportedException($"Cannot use OrderBy clause with the measure type {measureType}. Make sure to use first or last");
             }
-            var orderBy = Property<T>.Create(orderByExpression);
+            var orderBy = Property<TZ>.Create(orderByExpression);
             return new Measure<T>(property, measureType, orderBy);
         }
 

--- a/Chronological/Measure.cs
+++ b/Chronological/Measure.cs
@@ -18,9 +18,10 @@ namespace Chronological
     {
         internal readonly string MeasureType;
         internal readonly Property Property;
+        internal readonly Property OrderBy;
         public readonly T Value;
 
-        internal Measure (Property property, string measureType)
+        internal Measure(Property property, string measureType)
         {
             MeasureType = measureType;
             Property = property;
@@ -31,15 +32,29 @@ namespace Chronological
             Value = value;
         }
 
+        private Measure(Property property, string measureType, Property orderBy) : this(property, measureType)
+        {
+            OrderBy = orderBy;
+        }
+
         IMeasure IInternalMeasure.GetPopulatedMeasure(JValue value)
         {
             return new Measure<T>(Property, MeasureType, value.ToObject<T>());
         }
 
-        internal static Measure<T> Create<TY>(Expression<Func<TY, T>> propertyExpression, string measureType)
+        internal static Measure<T> Create<TY>(Expression<Func<TY, T>> propertyExpression, string measureType, Expression<Func<TY, T>> orderByExpression = null)
         {
             var property = Property<T>.Create(propertyExpression);
-            return new Measure<T>(property, measureType);            
+
+            if (orderByExpression == null)
+                return new Measure<T>(property, measureType);
+
+            if (measureType != Measure.LastMeasureExpression || measureType != Measure.FirstMeasureExpression)
+            {
+                throw new NotSupportedException($"Cannot use OrderBy clause with the measure type {measureType}. Make sure to use first or last");
+            }
+            var orderBy = Property<T>.Create(orderByExpression);
+            return new Measure<T>(property, measureType, orderBy);
         }
 
         internal static Measure<T> Create(string measureType)
@@ -53,6 +68,11 @@ namespace Chronological
             {
                 case (Measure.CountMeasureExpression):
                     return new JProperty(MeasureType, new JObject());
+                case (Measure.FirstMeasureExpression):
+                case (Measure.LastMeasureExpression):
+                    return new JProperty(MeasureType,
+                        new JObject(Property.ToInputJProperty()),
+                        OrderBy == null ? null : new JObject(OrderBy.ToInputJProperty()));
                 default:
                     return new JProperty(MeasureType, new JObject(Property.ToInputJProperty()));
             }
@@ -65,7 +85,7 @@ namespace Chronological
         internal const string MinimumMeasureExpression = "min";
         internal const string AverageMeasureExpression = "avg";
         internal const string SumMeasureExpression = "sum";
-		internal const string CountMeasureExpression = "count";
+        internal const string CountMeasureExpression = "count";
         internal const string LastMeasureExpression = "last";
         internal const string FirstMeasureExpression = "first";
     }

--- a/Chronological/Measure.cs
+++ b/Chronological/Measure.cs
@@ -59,12 +59,14 @@ namespace Chronological
         }
     }
 
-    public class Measure
+    public static class Measure
     {
         internal const string MaximumMeasureExpression = "max";
         internal const string MinimumMeasureExpression = "min";
         internal const string AverageMeasureExpression = "avg";
         internal const string SumMeasureExpression = "sum";
 		internal const string CountMeasureExpression = "count";
+        internal const string LastMeasureExpression = "last";
+        internal const string FirstMeasureExpression = "first";
     }
 }

--- a/Chronological/Measure.cs
+++ b/Chronological/Measure.cs
@@ -32,7 +32,7 @@ namespace Chronological
             Value = value;
         }
 
-        private Measure(Property property, string measureType, Property orderBy) : this(property, measureType)
+        internal Measure(Property property, string measureType, Property orderBy) : this(property, measureType)
         {
             OrderBy = orderBy;
         }
@@ -66,13 +66,17 @@ namespace Chronological
         {
             switch (MeasureType)
             {
-                case (Measure.CountMeasureExpression):
+                case Measure.CountMeasureExpression:
                     return new JProperty(MeasureType, new JObject());
-                case (Measure.FirstMeasureExpression):
-                case (Measure.LastMeasureExpression):
+                case Measure.FirstMeasureExpression:
+                case Measure.LastMeasureExpression:
+                    if (OrderBy == null)
+                        return new JProperty(MeasureType,
+                            new JObject(Property.ToInputJProperty()));
+
                     return new JProperty(MeasureType,
-                        new JObject(Property.ToInputJProperty()),
-                        OrderBy == null ? null : new JObject(OrderBy.ToInputJProperty()));
+                        new JObject(Property.ToInputJProperty(),
+                                    OrderBy.ToOrderByJProperty()));
                 default:
                     return new JProperty(MeasureType, new JObject(Property.ToInputJProperty()));
             }

--- a/Chronological/Property.cs
+++ b/Chronological/Property.cs
@@ -41,6 +41,11 @@ namespace Chronological
             return new JProperty("right", Name);
         }
 
+        internal JProperty ToOrderByJProperty()
+        {
+            return _isBuiltIn ? ToBuiltInJProperty("orderBy") : ToCustomJProperty("orderBy");
+        }
+
         private JProperty ToBuiltInJProperty(string outerName)
         {
             return new JProperty(outerName, new JObject(


### PR DESCRIPTION
Aggregate expressions allows to get two methods that were missing in the current version of Chronological, `last` and `first`. Both allow to get the latest, respectively the first value received for one particular property.

The specificity of those aggregate expressions is that they can take an optional parameter, `orderBy` which allows to define which property the elements should be ordered by and in which direction.

I've added the implementation for both first and last, with added unit tests for the Measures and the Aggregates.