### PR TITLE
Add possibility to check something is `NULL`

### DIFF
--- a/Chronological.Tests/FilterExpressionTests.cs
+++ b/Chronological.Tests/FilterExpressionTests.cs
@@ -61,7 +61,9 @@ namespace Chronological.Tests
             (x => x.DataType.EndsWith("Hello", StringComparison.Ordinal),                       "(endsWith_cs([data.type], 'Hello'))"),
             (x => x.DataType.EndsWith("Hello", StringComparison.OrdinalIgnoreCase),             "(endsWith([data.type], 'Hello'))"),
             (x => x.DataType.EndsWith("Hello", StringComparison.CurrentCultureIgnoreCase),      "(endsWith([data.type], 'Hello'))"),
-            (x => x.DataType.Contains("ello"),                                                  "(matchesRegex([data.type], '^.*ello.*'))")
+            (x => x.DataType.Contains("ello"),                                                  "(matchesRegex([data.type], '^.*ello.*'))"),
+            (x => x.DataType != null,                                                           "([data.type] != NULL)"),
+            (x => x.IsSimulated == null,                                                        "([data.isSimulated] = NULL)")
         };
 
         public static IEnumerable<object[]> TestCases

--- a/Chronological/Filter.cs
+++ b/Chronological/Filter.cs
@@ -225,6 +225,8 @@ namespace Chronological
                     return $"ts'P0Y0M{ts.Days}DT{ts.Hours}H{ts.Minutes}M{ts.Seconds}.{ts.Milliseconds}S'";
                 case DateTime dt:
                     return $"dt'{dt:O}'";
+                case null:
+                    return "NULL";
                 default:
                     throw new NotImplementedException();
             }


### PR DESCRIPTION
By adding `null` case in Filter.ConvertObjectToString, it is possible
to check that something is `NULL` or different than `NULL`.

Adds unit tests that checks that and implemented the fix.

Fixes issue #6