### PR TITLE
fix for issue #15 BuiltIn.EventTimeStamp is not copied

### DIFF
--- a/Chronological/QueryResults/Events/EventQueryResultToTypeMapper.cs
+++ b/Chronological/QueryResults/Events/EventQueryResultToTypeMapper.cs
@@ -64,8 +64,7 @@ namespace Chronological.QueryResults.Events
                         }
                         else if (typeProperty.CanWrite && attributes.Any(x => x.EventFieldName == BuiltIn.EventTimeStamp))
                         {
-                            if (propertyType.ToLower() == "datetime" &&
-                                (typeProperty.PropertyType == typeof(DateTime) || typeProperty.PropertyType == typeof(DateTime?)))
+                            if (propertyType.ToLower() == "datetime" && typeProperty.PropertyType == typeof(DateTime))
                             {
                                 typeProperty.SetValue(instance, DateTime.Parse(value));
                             }

--- a/Chronological/QueryResults/Events/EventQueryResultToTypeMapper.cs
+++ b/Chronological/QueryResults/Events/EventQueryResultToTypeMapper.cs
@@ -62,6 +62,14 @@ namespace Chronological.QueryResults.Events
                                 }
                             }
                         }
+                        else if (typeProperty.CanWrite && attributes.Any(x => x.EventFieldName == BuiltIn.EventTimeStamp))
+                        {
+                            if (propertyType.ToLower() == "datetime" &&
+                                (typeProperty.PropertyType == typeof(DateTime) || typeProperty.PropertyType == typeof(DateTime?)))
+                            {
+                                typeProperty.SetValue(instance, DateTime.Parse(value));
+                            }
+                        }
                     }
 
                 }


### PR DESCRIPTION
Fix for issue: If a property is bound to BuiltIn.EventTimeStamp its value isn't copied #15

In the case of $ts (BuiltIn.EventTimeStamp) the EventFiledName is not the property name but "$ts" (BuiltIn.EventTimeStamp)